### PR TITLE
Fixes #11: Standardize doc comments across config files

### DIFF
--- a/configs/import.js
+++ b/configs/import.js
@@ -1,97 +1,95 @@
-// 📦 Import necessary utilities and plugins for the flat configuration
-import { defineConfig } from "eslint/config"; // Utility for defining the flat config array
-import importPlugin from "eslint-plugin-import"; // The plugin containing import-related rules
+/**
+ * @module configs/import
+ * @description Enforces consistent import ordering, type-import style, and bans CommonJS require syntax.
+ */
+import { defineConfig } from "eslint/config";
+import importPlugin from "eslint-plugin-import";
 
-// 🚀 Export the configuration array
 export default defineConfig([
-  // --- Standard Configurations ---
-
-  // Applies the recommended set of import rules (e.g., no unused imports, etc.)
   importPlugin.flatConfigs.recommended,
-  // Extends the import rules to better handle TypeScript-specific imports/syntax
   importPlugin.flatConfigs.typescript,
-
-  // --- Custom Rule Overrides and Specific Configurations ---
 
   {
     rules: {
-      // 🛠️ Rule: Enforces a consistent and logical order for imports.
-      "import/order": ["error", {
-        // Defines the required order for different import types
-        "groups": ["type", "builtin", "external", "internal", ["parent", "sibling"], "index", "object"],
-        // A specific configuration to group 'react' as a 'builtin' and position it first among builtins.
-        "pathGroups": [
-          {
-            pattern: "react",
-            group: "builtin",
-            position: "before",
+      // Enforce grouped, alphabetized imports with React first
+      "import/order": [
+        "error",
+        {
+          "groups": [
+            "type",
+            "builtin",
+            "external",
+            "internal",
+            ["parent", "sibling"],
+            "index",
+            "object",
+          ],
+          "pathGroups": [
+            {
+              pattern: "react",
+              group: "builtin",
+              position: "before",
+            },
+          ],
+          "pathGroupsExcludedImportTypes": ["type"],
+          "newlines-between": "always",
+          "alphabetize": {
+            order: "asc",
+            caseInsensitive: true,
           },
-        ],
-        // Excludes 'type' imports from being affected by the 'pathGroups' ordering logic.
-        "pathGroupsExcludedImportTypes": ["type"],
-        // Forces a blank line between different import groups.
-        "newlines-between": "always",
-        // Sorts imports within the same group alphabetically (case-insensitive).
-        "alphabetize": {
-          order: "asc",
-          caseInsensitive: true,
         },
-      }],
+      ],
 
-      // 📐 Rule: Enforces using the `import type` syntax for type-only imports at the top level.
-      // E.g., `import type { MyType } from './file'` instead of `import { type MyType } from './file'`
+      // Prefer `import type { X }` over inline `import { type X }` for cleaner tree-shaking
       "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
 
-      // 🚫 Rule: Disallows imports that don't export anything (side-effect imports).
-      // The `allow` option is an exception for CSS imports, which are inherently for side effects (loading styles).
-      "import/no-unassigned-import": ["error", {
-        allow: ["**/*.css"],
-      }],
+      // Imports should actually use what they bring in; CSS is the exception since it just applies styles
+      "import/no-unassigned-import": [
+        "error",
+        {
+          allow: ["**/*.css"],
+        },
+      ],
 
-      // ⬇️ Rule: Ensures there's a newline after the last import statement.
+      // Visually separate imports from application code
       "import/newline-after-import": "error",
 
-      // 📦 Rule: Prevents importing packages using relative paths (e.g., `import '../package-name'`).
+      // Use package names, not relative paths between packages
       "import/no-relative-packages": "error",
 
-      // 🧭 Rule: Prevents using absolute paths on the file system (e.g., `/Users/user/project/file.js`).
+      // Prevent filesystem absolute paths (e.g., /Users/...)
       "import/no-absolute-path": "error",
 
-      // ♊ Rule: Disallows importing the same module multiple times.
+      // Catch accidental duplicate imports of the same module
       "import/no-duplicates": "error",
 
-      // 🔄 Rule: Prevents a module from importing itself, which leads to infinite loops.
+      // Prevent circular self-references
       "import/no-self-import": "error",
 
-      // ❌ Rule: Disallows CommonJS syntax (`require()`, `module.exports`), enforcing ES Modules.
+      // ESM only — no require() or module.exports
       "import/no-commonjs": "error",
 
-      // ⚖️ Rule: Sets a maximum number of dependencies a file can have (10, in this case).
-      // It's a 'warn' severity and ignores imports only used for types.
-      "import/max-dependencies": ["warn", {
-        max: 10,
-        ignoreTypeImports: true,
-      }],
+      // Flag files with too many dependencies as a complexity signal
+      "import/max-dependencies": [
+        "warn",
+        {
+          max: 10,
+          ignoreTypeImports: true,
+        },
+      ],
 
-      // --- Temporarily Disabled Rules ---
-
-      /* Causing errors, turning off for now. */
-      // Disabled: Type errors often arise when using TypeScript or complex environments.
+      /* Causing type-resolution errors; disabled until resolver config is stable */
       "import/default": 0,
       "import/no-named-as-default-member": 0,
-      "import/no-unresolved": 0, // Disabled: Typically handles by the `import/resolver` setting below.
+      "import/no-unresolved": 0,
     },
   },
 
-  // --- Global Settings for the Import Plugin ---
-
   {
     settings: {
-      // Configuration for how ESLint resolves imported modules.
       "import/resolver": {
-        // Tells the import plugin to use TypeScript's path resolution logic (via tsconfig.json).
+        // Use tsconfig paths for module resolution
         typescript: true,
-        // Also enables standard Node.js module resolution.
         node: true,
       },
     },

--- a/configs/js.js
+++ b/configs/js.js
@@ -1,41 +1,27 @@
-// 📦 Import necessary utilities and plugins for the flat configuration
-import js from "@eslint/js"; // Contains ESLint's core recommended rules
-import { defineConfig } from "eslint/config"; // Utility for defining the flat config array (optional but good practice)
+/**
+ * @module configs/js
+ * @description Extends ESLint recommended rules and warns on console usage.
+ */
+import js from "@eslint/js";
+import { defineConfig } from "eslint/config";
 
-// 🚀 Export the configuration array
 export default defineConfig([
-  // --- Standard Configurations ---
-
-  // Applies ESLint's default 'recommended' ruleset.
-  // This includes essential rules for catching common problems (e.g., no unused variables, no extra semicolons).
   js.configs.recommended,
-
-  // // This line is commented out, meaning rules from 'eslint-plugin-import' are NOT currently being used.
-  // importPlugin.flatConfigs.recommended,
-
-  // --- Custom Rule Overrides and Specific Configurations ---
 
   {
     rules: {
-
+      // TODO: Remove or re-enable import/no-unresolved config
       /*
-            // This section is commented out, meaning these import rules are NOT currently active.
-            // If enabled, this would:
-            // - Throw an error for imports that cannot be resolved ('import/no-unresolved').
-            // - Ignore case sensitivity during resolution.
-            // - Specifically ignore resolution warnings for 'eslint/config' and 'typescript-eslint' modules.
-                  "import/no-unresolved": ["error", {
-                    caseSensitive: false,
-                    ignore: [
-                      "eslint/config",
-                      "typescript-eslint",
-                    ],
-                  }],
-                    */
+            "import/no-unresolved": ["error", {
+              caseSensitive: false,
+              ignore: [
+                "eslint/config",
+                "typescript-eslint",
+              ],
+            }],
+              */
 
-      // 💬 Rule: Controls the use of console logging.
-      // - Sets the severity to 'warn' (does not break the build, just suggests fixing it).
-      // - It catches all console methods (log, error, warn, info, etc.).
+      // Catch accidental console statements left after debugging
       "no-console": ["warn"],
     },
   },

--- a/configs/json.js
+++ b/configs/json.js
@@ -1,31 +1,23 @@
-// 📦 Import necessary utilities and plugins for the flat configuration
-import stylistic from "@stylistic/eslint-plugin"; // The new plugin for purely stylistic rules
-import { defineConfig } from "eslint/config"; // Utility for defining the flat config array
+/**
+ * @module configs/json
+ * @description Disables stylistic rules that conflict with JSON syntax (semicolons, trailing commas, quote-props).
+ */
+import stylistic from "@stylistic/eslint-plugin";
+import { defineConfig } from "eslint/config";
 
-// 🚀 Export the configuration array
 export default defineConfig([
-  // --- Custom Rule Overrides and Plugin Registration ---
   {
     rules: {
-      // ❌ Disabled: Disables the rule that governs **quoting property names**.
-      // In JSON, property names *must* be double-quoted strings (e.g., `"key": "value"`).
-      // Disabling this rule ensures ESLint won't conflict with a code formatter (like Prettier)
-      // which is already enforcing the correct JSON format.
+      // JSON requires double-quoted keys; let the formatter handle it
       "@stylistic/quote-props": 0,
 
-      // ❌ Disabled: Disables the rule concerning **semicolons**.
-      // Semicolons are not valid syntax in JSON, so this rule is irrelevant and disabled.
+      // Semicolons are invalid in JSON
       "@stylistic/semi": 0,
 
-      // ❌ Disabled: Disables the rule that enforces or prohibits **trailing commas**.
-      // Trailing commas are *invalid* in standard JSON files. Disabling this rule allows
-      // a dedicated formatter to enforce the strict JSON rule of "no trailing commas."
+      // Trailing commas are invalid in JSON
       "@stylistic/comma-dangle": 0,
     },
 
-    // ⚙️ Plugin Registration:
-    // Registers the imported 'stylistic' module under the alias '@stylistic'.
-    // This makes the formatting rules available to check the JSON file's content.
     plugins: {
       "@stylistic": stylistic,
     },

--- a/configs/middleware.js
+++ b/configs/middleware.js
@@ -1,35 +1,32 @@
-// 📦 Import necessary utilities and plugins for the flat configuration
-import { defineConfig } from "eslint/config"; // Utility for defining the flat config array
-import tseslint from "typescript-eslint"; // The package for running ESLint with TypeScript
+/**
+ * @module configs/middleware
+ * @description Relaxes unused-variable rules for Express-style middleware signatures (req, res, next).
+ */
+import { defineConfig } from "eslint/config";
+import tseslint from "typescript-eslint";
 
-// 🚀 Export the configuration array
 export default defineConfig([
-  // --- Custom Rule Overrides and Configuration ---
   {
     rules: {
-      // 📐 Rule: Configures the TypeScript-specific unused variable check.
-      // This rule requires the plugin to be registered (in the block below).
-      "@typescript-eslint/no-unused-vars": ["error", {
-        // Sets the severity to 'error'.
-        // Ignores unused arguments in function signatures.
-        // This is crucial for middleware functions (e.g., `(req, res, next) => {...}`),
-        // where `req` or `next` might not be used in a particular handler.
-        args: "none",
-      }],
+      // Middleware signatures require all params (req, res, next) even if unused
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          args: "none",
+        },
+      ],
 
-      // ⚠️ Rule: The base ESLint rule for unused variables.
-      // This is often run alongside the TS version to catch non-type-specific unused variables.
-      // It's configured identically to the TS version.
-      "no-unused-vars": ["error", {
-        args: "none",
-      }],
+      // Mirror the TS rule for plain JS middleware files
+      "no-unused-vars": [
+        "error",
+        {
+          args: "none",
+        },
+      ],
     },
   },
 
-  // --- Plugin Registration ---
   {
-    // ⚙️ Plugin Registration:
-    // Registers the TypeScript ESLint plugin so its rules (like the one above) can be used.
     plugins: {
       "@typescript-eslint": tseslint.plugin,
     },

--- a/configs/react.js
+++ b/configs/react.js
@@ -1,71 +1,61 @@
-// 📦 Import necessary utilities and plugins for the flat configuration
-import { defineConfig } from "eslint/config"; // Utility for defining the flat config array
-import reactPlugin from "eslint-plugin-react"; // Core plugin for React syntax and conventions
-import reactHooks from "eslint-plugin-react-hooks"; // Plugin for enforcing rules of Hooks
-import reactRefresh from "eslint-plugin-react-refresh"; // Plugin for Hot Module Replacement (often used with Vite)
-import globals from "globals"; // Utility to define global variables (like 'window' or 'self')
+/**
+ * @module configs/react
+ * @description Configures React, Hooks, and React Refresh plugins with JSX runtime support.
+ */
+import { defineConfig } from "eslint/config";
+import reactPlugin from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import globals from "globals";
 
-// 🚀 Export the configuration array
 export default defineConfig([
-  // --- Standard Configurations ---
-
-  // Applies the recommended set of React rules (e.g., component naming, prop types, etc.).
   reactPlugin.configs.flat.recommended,
 
-  // Configures rules for the new JSX transform (where you don't need to import React
-  // at the top of every file containing JSX).
+  // Supports the new JSX transform (no need to import React in every file)
   reactPlugin.configs.flat["jsx-runtime"],
 
-  // Applies the recommended rules for React Hooks (e.g., Rules of Hooks).
   reactHooks.configs["recommended-latest"],
 
-  // Adds rules necessary for fast refresh/HMR to work correctly (often used in Vite/modern dev setups).
+  // HMR support for Vite dev server
   reactRefresh.configs.vite,
 
-  // --- Settings ---
   {
     settings: {
       react: {
-        // Automatically determines the installed React version. This is critical for
-        // ensuring the React plugin rules are compatible with your specific version.
+        // Ensures plugin rules match the installed React version
         version: "detect",
       },
     },
   },
 
-  // --- Language Options (Environment Setup) ---
   {
     languageOptions: {
-      // Inherits language options (like parser configuration) from the React recommended config.
       ...reactPlugin.configs.flat.recommended.languageOptions,
       globals: {
-        // Defines global variables available in a Service Worker context (e.g., 'self', 'caches').
         ...globals.serviceworker,
-        // Defines common global variables available in a browser environment (e.g., 'window', 'document').
         ...globals.browser,
       },
     },
   },
 
-  // --- Plugin Registration (Explicitly Registering React) ---
   {
     plugins: {
-      // Explicitly registers the core React plugin for use.
       react: reactPlugin,
     },
   },
 
-  // --- Custom Rules/Overrides ---
   {
     rules: {
-      // 🛠️ Rule: Enforces that if a JSX element has multiple props, the first prop starts on a new line.
-      // This is a stylistic rule intended to improve readability of multi-line JSX.
+      // Improve readability when a JSX element has multiple props
       "react/jsx-first-prop-new-line": ["warn", "multiline"],
 
-      // Rule: Needs to have functions allowed in order for TanStack Form to work.
-      "react/no-children-prop": ["error", {
-        allowFunctions: true,
-      }],
+      // Allow function children for TanStack Form's render-prop pattern
+      "react/no-children-prop": [
+        "error",
+        {
+          allowFunctions: true,
+        },
+      ],
     },
   },
 ]);

--- a/configs/stylistic.js
+++ b/configs/stylistic.js
@@ -1,98 +1,100 @@
-// 📦 Import necessary utilities and plugins for the flat configuration
-// NOTE: A large block of imports for other configs (e.g., storybook, react, tailwind) is commented out,
-// indicating this file currently only focuses on basic formatting.
-import stylistic from "@stylistic/eslint-plugin"; // The new plugin for purely stylistic rules
-import { defineConfig, globalIgnores } from "eslint/config"; // Utility for defining the config and global ignores
-import tseslint from "typescript-eslint"; // The package for running ESLint with TypeScript
+/**
+ * @module configs/stylistic
+ * @description Enforces formatting conventions: 2-space indent, double quotes, and strict JSX layout rules.
+ */
+import stylistic from "@stylistic/eslint-plugin";
+import { defineConfig, globalIgnores } from "eslint/config";
+import tseslint from "typescript-eslint";
 
-// 🚀 Export the configuration array
 export default defineConfig([
-  // --- Base Stylistic Configurations ---
-
-  // Applies the TypeScript ESLint plugin's stylistic configuration.
-  // This enables all TypeScript-aware stylistic rules (e.g., requiring consistent type member delimiters)
-  // and turns off any base ESLint rules that would conflict.
+  // TS-aware stylistic rules (e.g., consistent type member delimiters)
   tseslint.configs.stylistic,
 
-  // Applies the recommended set of stylistic rules from the dedicated plugin.
   stylistic.configs.recommended,
 
-  // Further customizes the stylistic rules.
   stylistic.configs.customize({
-    // Explicitly enables or enforces semicolons at the end of statements.
     semi: true,
   }),
 
-  // --- Plugin Registration ---
   {
-    // Explicitly registers the imported 'stylistic' module under the alias '@stylistic'.
     plugins: {
       "@stylistic": stylistic,
     },
   },
 
-  // --- Detailed Rule Overrides and Custom Formatting ---
   {
     rules: {
-      // 📏 Rule: Enforces **2 spaces** for indentation.
+      // Match project standard: 2-space indent
       "@stylistic/indent": ["error", 2],
 
-      // 💬 Rule: Enforces **double quotes** for strings.
+      // Match project standard: double quotes
       "@stylistic/quotes": ["error", "double"],
 
-      // 🧱 Rule: Ensures that **object properties are placed on separate lines** if they span multiple lines.
-      "@stylistic/object-property-newline": ["error", {
-        allowAllPropertiesOnSameLine: false, // Explicitly disallows multiple properties on one line.
-      }],
-
-      // 🖼️ Rule: Enforces **newlines inside object literals and patterns**.
-      "@stylistic/object-curly-newline": ["error", {
-        // Apply to object expressions (e.g., `{ a: 1, b: 2 }`).
-        ObjectExpression: {
-          multiline: true, // Newlines are required if the content spans multiple lines.
-          minProperties: 1, // Forces newlines if there is more than one property.
+      // One property per line for readable diffs
+      "@stylistic/object-property-newline": [
+        "error",
+        {
+          allowAllPropertiesOnSameLine: false,
         },
-        // Apply to object destructuring (e.g., `const { a, b } = obj`).
-        ObjectPattern: {
-          multiline: true,
-          minProperties: 1,
-        },
-      }],
+      ],
 
-      // ⬇️ Rule: Enforces **multiline function arguments** to start on new lines.
+      // Consistent newlines in object literals and destructuring
+      "@stylistic/object-curly-newline": [
+        "error",
+        {
+          ObjectExpression: {
+            multiline: true,
+            minProperties: 1,
+          },
+          ObjectPattern: {
+            multiline: true,
+            minProperties: 1,
+          },
+        },
+      ],
+
+      // Keep multiline function args readable
       "@stylistic/function-paren-newline": ["error", "multiline-arguments"],
 
-      // ⚙️ Rule: Enforces a consistent **brace style** (e.g., placing the opening brace on the same line).
+      // Consistent brace placement (same-line opening brace)
       "@stylistic/brace-style": "error",
 
-      // --- JSX Stylistic Rules ---
+      // --- JSX rules ---
 
-      // 📐 Rule: Enforces **2 spaces** for indentation of props in JSX.
+      // Match 2-space indent for JSX props
       "@stylistic/jsx-indent-props": ["error", 2],
 
-      // 📜 Rule: Forces a **maximum of one prop per line** in JSX elements.
-      "@stylistic/jsx-max-props-per-line": ["error", {
-        maximum: 1,
-      }],
+      // One prop per line for readable diffs
+      "@stylistic/jsx-max-props-per-line": [
+        "error",
+        {
+          maximum: 1,
+        },
+      ],
 
-      // 💬 Rule: Controls expressions allowed per line inside JSX.
-      // Allows non-JSX content (like strings or numbers) but forces JSX expressions onto new lines.
-      "@stylistic/jsx-one-expression-per-line": ["error", {
-        allow: "non-jsx",
-      }],
+      // Allow inline text but force JSX expressions onto new lines
+      "@stylistic/jsx-one-expression-per-line": [
+        "error",
+        {
+          allow: "non-jsx",
+        },
+      ],
 
-      // ⚛️ Rule: Enforces **self-closing tags** for components with no children (e.g., `<Component />`).
+      // Self-close components with no children (e.g., <Component />)
       "@stylistic/jsx-self-closing-comp": "error",
 
-      // 💡 Rule: Enforces **parentheses and newlines** when wrapping multiline JSX structures.
-      "@stylistic/jsx-wrap-multilines": ["error", {
-        declaration: "parens-new-line",
-        assignment: "parens-new-line",
-        return: "parens-new-line",
-        arrow: "parens-new-line",
-        condition: "parens-new-line",
-        logical: "parens-new-line",
-      }],
+      // Wrap multiline JSX in parens with newlines for clarity
+      "@stylistic/jsx-wrap-multilines": [
+        "error",
+        {
+          declaration: "parens-new-line",
+          assignment: "parens-new-line",
+          return: "parens-new-line",
+          arrow: "parens-new-line",
+          condition: "parens-new-line",
+          logical: "parens-new-line",
+        },
+      ],
     },
   },
 ]);

--- a/configs/tailwind.js
+++ b/configs/tailwind.js
@@ -1,48 +1,38 @@
-// 📦 Import necessary utilities and plugins
-import eslintParserTypeScript from "@typescript-eslint/parser"; // The parser needed to understand TypeScript and JSX syntax
-import { defineConfig } from "eslint/config"; // Utility for defining the flat config array
-import eslintPluginBetterTailwindcss from "eslint-plugin-better-tailwindcss"; // The plugin dedicated to Tailwind CSS rules
+/**
+ * @module configs/tailwind
+ * @description Enables Tailwind CSS class linting via eslint-plugin-better-tailwindcss.
+ */
+import eslintParserTypeScript from "@typescript-eslint/parser";
+import { defineConfig } from "eslint/config";
+import eslintPluginBetterTailwindcss from "eslint-plugin-better-tailwindcss";
 
-// 🚀 Export the configuration array
 export default defineConfig([
   {
-    // --- Language and Parsing Setup ---
     languageOptions: {
-      // ✍️ Parser: Tells ESLint to use the TypeScript parser.
-      // This allows ESLint to correctly understand TypeScript syntax (e.g., interfaces, generics)
-      // and JSX syntax, which is essential for linting React/Tailwind code.
+      // TS parser required to understand JSX class attributes
       parser: eslintParserTypeScript,
       parserOptions: {
         ecmaFeatures: {
-          // ⚛️ Enables support for JSX syntax.
           jsx: true,
         },
       },
     },
 
-    // --- Plugin Registration ---
     plugins: {
-      // Registers the imported Tailwind CSS plugin under the alias "better-tailwindcss".
       "better-tailwindcss": eslintPluginBetterTailwindcss,
     },
 
-    // --- Rule Configuration ---
     rules: {
-      // ⚠️ Includes all recommended rules from the plugin set to 'warn' severity.
-      // These rules typically cover non-critical but helpful suggestions for Tailwind usage.
+      // Non-critical suggestions (e.g., class ordering)
       ...eslintPluginBetterTailwindcss.configs["recommended-warn"].rules,
 
-      // ❌ Includes all recommended rules from the plugin set to 'error' severity.
-      // These rules usually cover critical errors like using unknown class names or violating core rules.
+      // Critical errors (e.g., unknown class names)
       ...eslintPluginBetterTailwindcss.configs["recommended-error"].rules,
     },
 
-    // --- Plugin Settings ---
     settings: {
       "better-tailwindcss": {
-        // 📌 Specifies the entry point CSS file for Tailwind.
-        // The plugin uses this file to correctly identify which Tailwind classes are
-        // actually available in the project, often referencing the `@tailwind` directives.
+        // Resolves available Tailwind classes from the project's CSS entry point
         entryPoint: "./src/index.css",
       },
     },

--- a/configs/tanstackQuery.js
+++ b/configs/tanstackQuery.js
@@ -1,9 +1,14 @@
+/**
+ * @module configs/tanstackQuery
+ * @description Applies TanStack Query recommended lint rules.
+ */
 import pluginQuery from "@tanstack/eslint-plugin-query";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
   ...pluginQuery.configs["flat/recommended"],
+  // No rule overrides yet
   {
-    rules: { /* overrides */ },
+    rules: {},
   },
 ]);

--- a/configs/tanstackRouter.js
+++ b/configs/tanstackRouter.js
@@ -1,9 +1,15 @@
+/**
+ * @module configs/tanstackRouter
+ * @description Applies TanStack Router recommended lint rules.
+ */
+// TODO: Import appears incorrect — should be @tanstack/eslint-plugin-router
 import pluginRouter from "@tanstack/eslint-plugin-query";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
   ...pluginRouter.configs["flat/recommended"],
+  // No rule overrides yet
   {
-    rules: { /* overrides */ },
+    rules: {},
   },
 ]);

--- a/configs/ts.js
+++ b/configs/ts.js
@@ -1,45 +1,30 @@
-// 📦 Import necessary utilities and plugins
-import { defineConfig } from "eslint/config"; // Utility for defining the flat config array
-import tseslint from "typescript-eslint"; // The package for running ESLint with TypeScript
+/**
+ * @module configs/ts
+ * @description Extends typescript-eslint recommended + strict rules, with underscore-prefix unused-var pattern.
+ */
+import { defineConfig } from "eslint/config";
+import tseslint from "typescript-eslint";
 
-// 🚀 Export the configuration array
 export default defineConfig([
-  // --- Standard Configurations ---
-
-  // 🤝 Applies the standard set of recommended rules for TypeScript.
-  // This includes essential rules like disallowing unused variables and requiring
-  // explicit types for functions in certain places.
   tseslint.configs.recommended,
 
-  // 🚨 Applies an extra set of stricter, more opinionated rules.
-  // This configuration emphasizes code correctness, safety, and readability,
-  // often catching potential runtime issues that the recommended config misses
-  // (e.g., disallowing non-null assertions and forcing stricter interface definitions).
+  // Stricter rules for correctness and safety (e.g., no non-null assertions)
   tseslint.configs.strict,
 
-  // --- Custom Rule Override ---
   {
     rules: {
-      // 🚫 Rule: Controls the usage of TypeScript directive comments (like @ts-ignore, @ts-nocheck).
-      "@typescript-eslint/ban-ts-comment": ["error", {
-        // Sets the severity to 'error', meaning any violation breaks the build.
+      // Allow @ts-expect-error only with a description explaining why
+      "@typescript-eslint/ban-ts-comment": [
+        "error",
+        {
+          "ts-expect-error": "allow-with-description",
+        },
+      ],
 
-        // 💬 Exception: Allows the use of '// @ts-expect-error' only if it is accompanied
-        // by a description explaining why the error is expected and suppressed.
-        "ts-expect-error": "allow-with-description",
-
-        // Other directive comments (like @ts-ignore, @ts-nocheck) are implicitly banned by default
-        // when using the recommended and strict configs, reinforcing code quality.
-      }],
-
-      // 🛑 Disable the standard JavaScript rule.
-      // This rule must be turned off because it does not understand TypeScript syntax
-      // (like interfaces, types, or enum members) and will report false positives.
+      // Base rule gives false positives with TS syntax; use @typescript-eslint version below
       "no-unused-vars": "off",
 
-      // ✨ Enable the TypeScript-specific rule for unused variables.
-      // This version correctly handles TypeScript features and allows for granular configuration
-      // regarding which variables can be safely ignored.
+      // Unused vars prefixed with _ are intentional (e.g., destructuring to omit)
       "@typescript-eslint/no-unused-vars": [
         "error",
         {


### PR DESCRIPTION
## ELI5
The config files had a mix of comment styles — some were covered in emoji-heavy explanations, others had no comments at all. This PR makes them all consistent by adding a short description at the top of each file and rewriting inline comments to explain *why* a rule is set up that way instead of just restating what it does.

## Summary
- Added standardized JSDoc headers (`@module` + `@description`) to all 10 config files in `configs/`
- Replaced verbose emoji-annotated comments with concise, WHY-focused inline comments
- Added missing comments to bare files (`tanstackQuery.js`, `tanstackRouter.js`)
- Flagged likely incorrect import in `tanstackRouter.js` (imports query plugin instead of router)
- Removed orphaned/redundant comments (section dividers, import-line explanations, export annotations)

## Test plan
- [ ] Run `pnpm lint` — should pass clean
- [ ] Review each file's JSDoc header for accuracy
- [ ] Review inline comments for correct WHY explanations
- [ ] Verify no actual code/rules were changed (comment-only diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)